### PR TITLE
Up Maven version to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,26 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ github.sha }}
+      - run: ./mvnw clean install -e -B -V
+  test:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ '11', '17', '21' ]
+        java: [ '8', '11', '17', '21' ]
+        maven: [ '3.6.3', '3.8.8', '3.9.6' ]
       fail-fast: false
-
     runs-on: ${{ matrix.os }}
-
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -25,7 +37,10 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
           cache: 'maven'
-
-      - name: Build with Maven
-        run: ./mvnw verify -e -B -V
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ github.sha }}
+      - run: ./mvnw -e -B -V -Dmaven=${{ matrix.maven }} -Dtype=only-script wrapper:wrapper
+      - run: ./mvnw -f its verify -e -B -V
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
           distribution: 'temurin'
       - uses: actions/cache@v4
         with:
+          enableCrossOsArchive: true
           path: ~/.m2/repository
           key: maven-${{ github.sha }}
       - run: ./mvnw clean install -e -B -V
@@ -40,6 +41,7 @@ jobs:
           cache: 'maven'
       - uses: actions/cache@v4
         with:
+          enableCrossOsArchive: true
           path: ~/.m2/repository
           key: maven-${{ github.sha }}
       - run: ./mvnw -e -B -V -Dmaven=${{ matrix.maven }} -Dtype=only-script wrapper:wrapper

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,8 @@ jobs:
           key: maven-${{ github.sha }}
       - run: ./mvnw -e -B -V -Dmaven=${{ matrix.maven }} -Dtype=only-script wrapper:wrapper
       - run: ./mvnw -f its verify -e -B -V
-
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: its-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.maven }}
+          path: ./its/target/classes/its

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '21' ]
         maven: [ '3.6.3', '3.8.8', '3.9.6' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'temurin'
+          distribution: 'zulu'
           cache: 'maven'
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
           key: maven-${{ github.sha }}
       - run: ./mvnw clean install -e -B -V
   test:
+    needs: build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           distribution: 'temurin'
       - uses: actions/cache@v4
         with:
-          enableCrossOsArchive: true
           path: ~/.m2/repository
           key: maven-${{ github.sha }}
       - run: ./mvnw clean install -e -B -V
@@ -27,8 +26,8 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ '8', '21' ]
+        os: [ubuntu-latest]
+        java: [ '8', '11', '17', '21' ]
         maven: [ '3.6.3', '3.8.8', '3.9.6' ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -37,11 +36,10 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'maven'
       - uses: actions/cache@v4
         with:
-          enableCrossOsArchive: true
           path: ~/.m2/repository
           key: maven-${{ github.sha }}
       - run: ./mvnw -e -B -V -Dmaven=${{ matrix.maven }} -Dtype=only-script wrapper:wrapper

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ ~ Copyright (c) 2010-present Sonatype, Inc.
+ ~ All rights reserved. This program and the accompanying materials
+ ~ are made available under the terms of the Eclipse Public License v1.0
+ ~ which accompanies this distribution, and is available at
+ ~ http://www.eclipse.org/legal/epl-v10.html
+ ~
+ ~ Contributors:
+ ~   Stuart McCulloch (Sonatype, Inc.) - initial API and implementation
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.eclipse.sisu</groupId>
+  <artifactId>its</artifactId>
+  <version>0.9.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Sisu Maven Plugin ITs</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype-nexus-snapshots</id>
+      <name>Sonatype Nexus Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <id>its</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <cloneProjectsTo>${project.build.outputDirectory}/its</cloneProjectsTo>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/its/src/it/simple/pom.xml
+++ b/its/src/it/simple/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>simple</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Simple test for sisu-maven-plugin</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <version>1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.sisu</groupId>
+                <artifactId>sisu-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <executions>
+                    <execution>
+                        <id>index-project</id>
+                        <goals>
+                            <goal>main-index</goal>
+                            <goal>test-index</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/its/src/it/simple/pom.xml
+++ b/its/src/it/simple/pom.xml
@@ -31,6 +31,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.eclipse.sisu</groupId>
                 <artifactId>sisu-maven-plugin</artifactId>
                 <version>@project.version@</version>

--- a/its/src/it/simple/pom.xml
+++ b/its/src/it/simple/pom.xml
@@ -20,6 +20,12 @@
             <artifactId>javax.inject</artifactId>
             <version>1</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/its/src/it/simple/src/main/java/org/eclipse/sisu/mojos/its/simple/Component.java
+++ b/its/src/it/simple/src/main/java/org/eclipse/sisu/mojos/its/simple/Component.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2010-present Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Stuart McCulloch (Sonatype, Inc.) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sisu.mojos;
+
+import javax.inject.Named;
+
+@Named
+public class Component {
+}

--- a/its/src/it/simple/src/test/java/org/eclipse/sisu/mojos/its/simple/ComponentTest.java
+++ b/its/src/it/simple/src/test/java/org/eclipse/sisu/mojos/its/simple/ComponentTest.java
@@ -10,8 +10,11 @@
  *******************************************************************************/
 package org.eclipse.sisu.mojos;
 
+import org.junit.Test;
 import javax.inject.Named;
 
 @Named
 public class ComponentTest {
+    @Test
+    public void dummyTest() {}
 }

--- a/its/src/it/simple/src/test/java/org/eclipse/sisu/mojos/its/simple/ComponentTest.java
+++ b/its/src/it/simple/src/test/java/org/eclipse/sisu/mojos/its/simple/ComponentTest.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2010-present Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Stuart McCulloch (Sonatype, Inc.) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sisu.mojos;
+
+import javax.inject.Named;
+
+@Named
+public class ComponentTest {
+}

--- a/its/src/it/simple/verify.groovy
+++ b/its/src/it/simple/verify.groovy
@@ -1,0 +1,8 @@
+var mainIndex = new File(basedir, "target/classes/META-INF/sisu/javax.inject.Named")
+var testIndex = new File(basedir, "target/test-classes/META-INF/sisu/javax.inject.Named")
+
+assert mainIndex.exists()
+assert mainIndex.text.contains('org.eclipse.sisu.mojos.Component')
+
+assert testIndex.exists()
+assert testIndex.text.contains('org.eclipse.sisu.mojos.ComponentTest')

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <mavenRuntimeVersion>3.2.5</mavenRuntimeVersion>
-    <mavenBuildVersion>3.6.3</mavenBuildVersion>
+    <mavenRuntimeVersion>3.6.3</mavenRuntimeVersion>
+    <mavenBuildVersion>3.9.6</mavenBuildVersion>
     <javaBuildVersion>11</javaBuildVersion>
     <mavenPluginToolsVersion>3.13.0</mavenPluginToolsVersion>
   </properties>


### PR DESCRIPTION
To compile against, and raise the Maven prerequisite to 3.6.3 (have it aligned with other Maven Core plugins).

As Maven 3.6.3 triggers dependabot alert... but also to follow the trend, am unsure is Maven 3.2.x used in 2024.